### PR TITLE
Removing references to *yahoo* inside callback url and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ specifying a consumer key, consumer secret, and callback URL.
     passport.use(new YahooStrategy({
         consumerKey: YAHOO_CONSUMER_KEY,
         consumerSecret: YAHOO_CONSUMER_SECRET,
-        callbackURL: "http://127.0.0.1:3000/auth/yahoo/callback"
+        callbackURL: "http://127.0.0.1:3000/auth/callback"
       },
       function(token, tokenSecret, profile, done) {
         User.findOrCreate({ yahooId: profile.id }, function (err, user) {
@@ -45,10 +45,10 @@ authenticate requests.
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
-    app.get('/auth/yahoo',
+    app.get('/auth',
       passport.authenticate('yahoo'));
 
-    app.get('/auth/yahoo/callback',
+    app.get('/auth/callback',
       passport.authenticate('yahoo', { failureRedirect: '/login' }),
       function(req, res) {
         // Successful authentication, redirect home.

--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -30,12 +30,12 @@ passport.deserializeUser(function(obj, done) {
 passport.use(new YahooStrategy({
     consumerKey: YAHOO_CONSUMER_KEY,
     consumerSecret: YAHOO_CONSUMER_SECRET,
-    callbackURL: "http://127.0.0.1:3000/auth/yahoo/callback"
+    callbackURL: "http://127.0.0.1:3000/auth/callback"
   },
   function(token, tokenSecret, profile, done) {
     // asynchronous verification, for effect...
     process.nextTick(function () {
-      
+
       // To keep the example simple, the user's Yahoo profile is returned to
       // represent the logged-in user.  In a typical application, you would want
       // to associate the Yahoo account with a user record in your database,
@@ -85,7 +85,7 @@ app.get('/login', function(req, res){
 //   request.  The first step in Yahoo authentication will involve redirecting
 //   the user to yahoo.com.  After authorization, Yahoo will redirect the user
 //   back to this application at /auth/yahoo/callback
-app.get('/auth/yahoo',
+app.get('/auth',
   passport.authenticate('yahoo'),
   function(req, res){
     // The request will be redirected to Yahoo for authentication, so this
@@ -97,7 +97,7 @@ app.get('/auth/yahoo',
 //   request.  If authentication fails, the user will be redirected back to the
 //   login page.  Otherwise, the primary route function function will be called,
 //   which, in this example, will redirect the user to the home page.
-app.get('/auth/yahoo/callback', 
+app.get('/auth/callback', 
   passport.authenticate('yahoo', { failureRedirect: '/login' }),
   function(req, res) {
     res.redirect('/');

--- a/examples/login/views/login.ejs
+++ b/examples/login/views/login.ejs
@@ -1,1 +1,1 @@
-<a href="/auth/yahoo">Login with Yahoo</a>
+<a href="/auth">Login with Yahoo</a>


### PR DESCRIPTION
Not sure when Yahoo updated this, but you cannot copy/paste the example to get it working, you'll run into this error when setting up your Y! Application.

![screenshot 2017-10-21 16 17 52](https://user-images.githubusercontent.com/2190191/31855163-7388352c-b67b-11e7-8453-f6de090ceecd.png)
